### PR TITLE
Update big_data.tf

### DIFF
--- a/terraform/gcp/big_data.tf
+++ b/terraform/gcp/big_data.tf
@@ -6,6 +6,7 @@ resource "google_sql_database_instance" "master_instance" {
   settings {
     tier = "db-f1-micro"
     ip_configuration {
+    require_ssl = true
       ipv4_enabled = true
       authorized_networks {
         name  = "WWW"


### PR DESCRIPTION
GCP SQL Instances do not have SSL configured for incoming connections Last updated: 
March 8, 2024
Policy Details
Prisma Cloud Policy ID 	b497449f-7a19-49e0-a715-8d0cc95090e9 Checkov ID 	CKV_GCP_6
Severity 	HIGH
Subtype 	Build
Frameworks 	Terraform,TerraformPlan
Description

Cloud SQL is a fully managed relational database service for MySQL, PostgreSQL and SQL Server. It offers data encryption at rest and in transit, Private connectivity with VPC and user-controlled network access with firewall protection. Cloud SQL creates a server certificate automatically when a new instance is created. We recommend you enforce all connections to use SSL/TLS. Fix - Buildtime